### PR TITLE
Fix: specify types file in package.json for API typing to work properly

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
 	"type": "module",
 	"exports": {
 		"import": "./dist/api-esm.mjs",
-		"require": "./dist/api-cjs.js"
+		"require": "./dist/api-cjs.js",
+		"types": "./dist/api.d.ts"
 	},
 	"scripts": {
 		"dev": "node esbuild.config.mjs",


### PR DESCRIPTION
Apologies if this was just an error on my part that I'm not realizing, but I was trying to use the Callout Manager API in a plugin today, and TypeScript was failing to recognize the typings provided in the package:

<img width="1201" alt="Screen Shot 2024-10-07 at 7 51 09 PM" src="https://github.com/user-attachments/assets/786d6496-dc53-49b8-b75f-d56e558523bc">


```
Could not find a declaration file for module 'obsidian-callout-manager'. '/Users/alythobani/dev/obsidian-development-vault/.obsidian/plugins/obsidian-callout-commands/node_modules/obsidian-callout-manager/dist/api-esm.mjs' implicitly has an 'any' type.
  There are types at '/Users/alythobani/dev/obsidian-development-vault/.obsidian/plugins/obsidian-callout-commands/node_modules/obsidian-callout-manager/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'obsidian-callout-manager' library may need to update its package.json or typings.ts(7016)
```

Adding this `exports.types` field to `package.json` seems to fix things for my plugin's import of the API. Guessing it's because the names aren't synced (`api.d.ts` isn't being automatically associated with `api-esm.mjs` / `api-esm-esnext.mjs` / `api-cjs.js`).