### PR TITLE
Enabling callout names with non-English letters

### DIFF
--- a/src/panes/create-callout-pane.ts
+++ b/src/panes/create-callout-pane.ts
@@ -63,7 +63,7 @@ export function makeTextComponentValidateCalloutID(cmp: TextComponent, id: strin
 	cmp.then(({ inputEl }) => {
 		const update = vs.addSource(id);
 
-		inputEl.setAttribute('pattern', '^[a-z\\-]{1,}$');
+		inputEl.setAttribute('pattern', '^[\p{L}\p{M}\\-]+$');
 		inputEl.setAttribute('required', 'required');
 		inputEl.addEventListener('change', onChange);
 		inputEl.addEventListener('input', onChange);


### PR DESCRIPTION
This proposed change modified the regex from `^[a-z\\-]{1,}$` to `^[\p{L}\p{M}\\-]+$`, which matches any letter, ideograph, letter with accent (etc.)[^1] and backslashes and dashes (as per the original), instead of only English (Latin) letters, backslashes and dashes. I also modified `{1,}` to `+` just for clarity.

This pull request stems from issue #17, and I hope it fixes it.

I'll admit this isn't tested in Obsidian (I have tested the Regex of course), as I haven't developed an Obsidian plugin in the past and have no idea how to do so, but it's coded.

[^1]: [Source](https://stackoverflow.com/a/6005511/17396626)