### PR TITLE
fix: allow callout preview in Edit Callout pane to be visible

### DIFF
--- a/src/ui/component/callout-preview.ts
+++ b/src/ui/component/callout-preview.ts
@@ -437,5 +437,6 @@ const SHADOW_DOM_RESET_STYLES = `
 /* Use transparent background color. */
 body {
 	background-color: transparent !important;
+	contain: none;
 }
 `;


### PR DESCRIPTION
Hey, I noticed there's supposed to be a callout preview in the Edit Callout pane, but it's invisible.

Turns out there's a `contain: strict;` on the `body` element inside the shadow root, that was causing the callout preview to be hidden. Overriding it with `contain: none` allows the preview to be visible. Pretty simple 1-line fix :)

## Screenshots

### Before

<img width="1100" height="919" alt="Screen Shot 2026-04-18 at 2 04 11 PM" src="https://github.com/user-attachments/assets/3c46f0ab-d016-4e61-be49-82d58f53f1ad" />

### After

<img width="1099" height="919" alt="Screen Shot 2026-04-18 at 2 03 27 PM" src="https://github.com/user-attachments/assets/89e55f3c-9894-479e-9706-ca64834884db" />

---

I know you're not too active here anymore, but thanks so much for making this plugin, it's one of my absolute favorites in Obsidian. Soooo convenient and useful.